### PR TITLE
fix runtime problems with firestore conformance test generator

### DIFF
--- a/testing/firestore/Makefile
+++ b/testing/firestore/Makefile
@@ -7,16 +7,16 @@
 # - protoc is on the path.
 # - protoc supports proto3 syntax.
 # - The Go protoc plugin has been downloaded and installed.
-# - The github.com/google/protobuf repo has been cloned locally.
-# - The github.com/googleapis/googleapis repo has been cloned locally.
+# - The github.com/google/protobuf repo has been cloned locally (go get github.com/google/protobuf).
+# - The github.com/googleapis/googleapis repo has been cloned locally (go get github.com/googleapis/googleapis).
 
 PROTOC = protoc
 
 PROTOC_GO_PLUGIN_DIR = $(GOPATH)/bin
 
 # Dependent repos.
-PROTOBUF_REPO = $(HOME)/git-repos/protobuf
-GOOGLEAPIS_REPO = $(HOME)/git-repos/googleapis
+PROTOBUF_REPO = $(GOPATH)/src/github.com/golang/protobuf
+GOOGLEAPIS_REPO = $(GOPATH)/src/github.com/googleapis/googleapis
 
 .PHONY: generate-tests sync-protos gen-protos generator
 

--- a/testing/firestore/cmd/generate-firestore-tests/generate-firestore-tests.go
+++ b/testing/firestore/cmd/generate-firestore-tests/generate-firestore-tests.go
@@ -23,11 +23,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	tpb "github.com/GoogleCloudPlatform/google-cloud-common/testing/firestore/genproto"
+	tpb "github.com/googleapis/google-cloud-common/testing/firestore/genproto"
 	"github.com/golang/protobuf/proto"
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	fspb "google.golang.org/genproto/googleapis/firestore/v1beta1"
+	fspb "google.golang.org/genproto/googleapis/firestore/v1"
 )
 
 const (


### PR DESCRIPTION
Fix runtime problems: firestore should be using v1 not v1beta1.

Also makes the makefile a bit more approachable by having the
instructions use `go get` and $GOPATH.